### PR TITLE
feat: Ignore html comments

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,11 @@ import type { HtmxExtension } from "htmx.org";
 
           let response = xhr.response as string;
 
+          // Skip comment-only chunks (heartbeats), but allow empty chunks through
+          const hasComment = /<!--[\s\S]*?-->/.test(response);
+          const stripped = response.replace(/<!--[\s\S]*?-->/g, "").trim();
+          if (hasComment && stripped.length === 0) return;
+
           api.withExtensions(elt, function (extension) {
             if (!extension.transformResponse) return;
             response = extension.transformResponse(response, xhr, elt);


### PR DESCRIPTION
This allows for sending heartbeats from server side during long lasting requests without modifying the DOM. Empty strings and comments mixed with html will still pass through but comment only will be ignored.

This change kind of only makes sense as a complement to [PR182](https://github.com/douglasduteil/htmx.ext...chunked-transfer/pull/182 ). 