### PR TITLE
fix: htmx v2 compatibility with proper type declarations

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,11 @@
 //
 
 import type { HtmxExtension } from "htmx.org";
+import type htmxType from "htmx.org";
+
+//
+
+declare const htmx: typeof htmxType;
 
 //
 
@@ -49,15 +54,6 @@ import type { HtmxExtension } from "htmx.org";
     },
   } as HtmxExtension & { init: (apiRef: any) => void });
 })();
-
-//
-
-declare global {
-  var htmx: typeof import("htmx.org");
-  interface Window {
-    htmx: typeof import("htmx.org");
-  }
-}
 
 //
 // Inspired by https://github.com/delaneyj/nothtmx2


### PR DESCRIPTION
Changed from global type declaration to local const declaration with proper htmx types imported. This fixes the TypeScript compilation error while keeping the bundle clean (no htmx code included in output).

Fixes: Property 'defineExtension' does not exist on type error